### PR TITLE
Removed SL4J binding dependency declaration to conform with SLF4J docume...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,6 @@
 			<version>1.7.5</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.5</version>
-		</dependency>
-		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.17</version>


### PR DESCRIPTION
...ntation

Thanks for the project and for looking at this pull request. Removed binding dependency declaration because it was breaking our project. We had to specifically exclude the binding JAR to get our already declared binding JAR to work. According to SLF4J documentation: "Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api. When a library declares a compile-time dependency on a SLF4J binding, it imposes that binding on the end-user, thus negating SLF4J's purpose. When you come across an embedded component declaring a compile-time dependency on any SLF4J binding, please take the time to contact the authors of said component/library and kindly ask them to mend their ways."
